### PR TITLE
Add Clover device types and optional terminal receipt printing

### DIFF
--- a/pos_cardpointe_poc/models/cardpointe_terminal_config.py
+++ b/pos_cardpointe_poc/models/cardpointe_terminal_config.py
@@ -14,8 +14,21 @@ class CardPointeTerminalConfig(models.Model):
     merchant_id = fields.Char(default='800000009875', required=True)
     merchant_config_id = fields.Many2one('cardpointe.merchant.config')
     auth_key = fields.Char(required=True)
-    device_type = fields.Selection([('clover_flex', 'Clover Flex')], default='clover_flex', required=True)
+    device_type = fields.Selection(
+        [
+            ('clover_pocket', 'Clover Pocket'),
+            ('clover_flex', 'Clover Flex'),
+            ('clover_mini', 'Clover Mini'),
+        ],
+        default='clover_pocket',
+        required=True,
+    )
     device_serial = fields.Char(string='HSN', help='Terminal hardware serial number (HSN).')
+    print_receipt_on_terminal = fields.Boolean(
+        string='Print Receipt on Terminal',
+        default=False,
+        help='Enable receipt printing on supported Clover terminals with built-in printers.',
+    )
     request_timeout_seconds = fields.Integer(default=120, required=True)
     signature_mode = fields.Selection(
         [

--- a/pos_cardpointe_poc/services/cardpointe_terminal.py
+++ b/pos_cardpointe_poc/services/cardpointe_terminal.py
@@ -224,6 +224,14 @@ class CardPointeTerminalClient:
             'orderId': order_id,
             'includeSignature': bool(include_signature),
         }
+        receipt_requested = bool(self.config.print_receipt_on_terminal)
+        if self.config.device_type == 'clover_flex':
+            payload['printReceipt'] = receipt_requested
+        _logger.info(
+            "CardPointe authCard receipt printing requested=%s device_type=%s",
+            receipt_requested if self.config.device_type == 'clover_flex' else False,
+            self.config.device_type,
+        )
         result = self._request(
             'POST',
             '/v4/authCard',

--- a/pos_cardpointe_poc/tests/__init__.py
+++ b/pos_cardpointe_poc/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_signature_policy
+from . import test_terminal_auth_payload

--- a/pos_cardpointe_poc/tests/test_terminal_auth_payload.py
+++ b/pos_cardpointe_poc/tests/test_terminal_auth_payload.py
@@ -1,0 +1,86 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+def _load_terminal_module():
+    http_module = types.ModuleType('odoo.addons.payment_cardpointe_base.services.http')
+    http_module.CardPointeRequestError = Exception
+    http_module.redact_payload = lambda payload: payload
+    http_module.request_json = lambda *args, **kwargs: (200, {}, '{}', {})
+    http_module.safe_log_headers = lambda headers: headers
+    http_module.safe_truncate = lambda value, limit=200: value
+
+    money_module = types.ModuleType('odoo.addons.payment_cardpointe_base.services.money')
+    money_module.dollars_to_implied_cents = lambda amount: str(int(round(float(amount) * 100)))
+
+    normalize_module = types.ModuleType('odoo.addons.payment_cardpointe_base.services.normalize')
+    normalize_module.normalize_terminal_authcard_response = (
+        lambda http_status, data: {'ok': True, 'status': 'ok', 'resptext': 'ok'}
+    )
+
+    sys.modules.setdefault('odoo', types.ModuleType('odoo'))
+    sys.modules.setdefault('odoo.addons', types.ModuleType('odoo.addons'))
+    sys.modules.setdefault('odoo.addons.payment_cardpointe_base', types.ModuleType('odoo.addons.payment_cardpointe_base'))
+    sys.modules.setdefault(
+        'odoo.addons.payment_cardpointe_base.services',
+        types.ModuleType('odoo.addons.payment_cardpointe_base.services'),
+    )
+    sys.modules['odoo.addons.payment_cardpointe_base.services.http'] = http_module
+    sys.modules['odoo.addons.payment_cardpointe_base.services.money'] = money_module
+    sys.modules['odoo.addons.payment_cardpointe_base.services.normalize'] = normalize_module
+
+    module_path = pathlib.Path(__file__).resolve().parents[1] / 'services' / 'cardpointe_terminal.py'
+    spec = importlib.util.spec_from_file_location('cardpointe_terminal', module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Config:
+    def __init__(self, device_type, print_receipt_on_terminal):
+        self.base_url = 'https://bolt-uat.cardpointe.com/api'
+        self.auth_key = 'secret'
+        self.merchant_id = 'mid'
+        self.device_serial = 'hsn'
+        self.request_timeout_seconds = 30
+        self.device_type = device_type
+        self.print_receipt_on_terminal = print_receipt_on_terminal
+
+
+class TestTerminalAuthPayload(unittest.TestCase):
+    def setUp(self):
+        self.module = _load_terminal_module()
+
+    def test_auth_payload_sends_print_receipt_for_flex(self):
+        client = self.module.CardPointeTerminalClient(_Config('clover_flex', True))
+        seen = {}
+
+        def fake_request(method, path, payload=None, session_key=None, timeout=30):
+            seen['payload'] = dict(payload or {})
+            return {'ok': False, 'status': 'error', 'message': 'stop'}
+
+        client._request = fake_request
+        client.auth_card_with_session(1.00, 'ORDER-1', 'SESSION-1', include_signature=True)
+
+        self.assertIn('printReceipt', seen['payload'])
+        self.assertTrue(seen['payload']['printReceipt'])
+
+    def test_auth_payload_omits_print_receipt_for_pocket(self):
+        client = self.module.CardPointeTerminalClient(_Config('clover_pocket', True))
+        seen = {}
+
+        def fake_request(method, path, payload=None, session_key=None, timeout=30):
+            seen['payload'] = dict(payload or {})
+            return {'ok': False, 'status': 'error', 'message': 'stop'}
+
+        client._request = fake_request
+        client.auth_card_with_session(1.00, 'ORDER-1', 'SESSION-1', include_signature=False)
+
+        self.assertNotIn('printReceipt', seen['payload'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pos_cardpointe_poc/views/cardpointe_terminal_config_views.xml
+++ b/pos_cardpointe_poc/views/cardpointe_terminal_config_views.xml
@@ -18,6 +18,8 @@
                         <field name="base_url"/>
                         <field name="merchant_id"/>
                         <field name="device_type"/>
+                        <field name="print_receipt_on_terminal"
+                               attrs="{'invisible': [('device_type', '!=', 'clover_flex')]}"/>
                         <field name="device_serial"/>
                         <field name="auth_key" password="True"/>
                         <field name="request_timeout_seconds"/>


### PR DESCRIPTION
### Motivation
- Expand Clover terminal support conservatively by adding explicit Clover device_type options and a terminal-level flag to request receipt printing when the selected device supports it.
- Preserve existing behavior for current setups by introducing `clover_pocket` as the new default device type.
- Keep changes minimal, Odoo-native, and avoid touching unrelated signature policy layout or reprint logic.

### Description
- Extended `pos.cardpointe.terminal.config.device_type` to include `clover_pocket`, `clover_flex`, and `clover_mini`, and set the default to `clover_pocket` to preserve current behavior.
- Added terminal boolean field `print_receipt_on_terminal` (`default=False`) with help text describing it applies to Clover terminals with built-in printers, defined on `pos.cardpointe.terminal.config`.
- Updated the terminal config form to show the `Print Receipt on Terminal` field in the main config area and make it visible only when `device_type` is `clover_flex`, keeping the signature policy group unchanged.
- Updated `CardPointeTerminalClient.auth_card_with_session()` so that the `/v4/authCard` payload includes `printReceipt` only when `device_type == 'clover_flex'`, and added an INFO log line indicating whether receipt printing was requested without logging sensitive payload details.
- Added a focused unit test `pos_cardpointe_poc/tests/test_terminal_auth_payload.py` that verifies the auth payload includes `printReceipt` for `clover_flex` and omits it for `clover_pocket`; registered the test in `pos_cardpointe_poc/tests/__init__.py`.

### Testing
- Ran `python pos_cardpointe_poc/tests/test_signature_policy.py` and it passed locally (existing signature policy tests remain green).
- Ran `python pos_cardpointe_poc/tests/test_terminal_auth_payload.py` and it passed locally (verifies payload construction behavior for Flex vs Pocket).
- Attempted `python -m unittest pos_cardpointe_poc.tests.test_signature_policy pos_cardpointe_poc.tests.test_terminal_auth_payload` which failed in this environment due to `ModuleNotFoundError: No module named 'odoo'` when loading the package; this is an environment import issue and not a functional test failure for the changed code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c969bca7ac832895e9078109bbe266)