### PR TITLE
Support terminal receipt printing for Clover Flex and add CardPointe receipt reprint scaffold

### DIFF
--- a/pos_cardpointe_poc/models/cardpointe_terminal_config.py
+++ b/pos_cardpointe_poc/models/cardpointe_terminal_config.py
@@ -14,8 +14,21 @@ class CardPointeTerminalConfig(models.Model):
     merchant_id = fields.Char(default='800000009875', required=True)
     merchant_config_id = fields.Many2one('cardpointe.merchant.config')
     auth_key = fields.Char(required=True)
-    device_type = fields.Selection([('clover_flex', 'Clover Flex')], default='clover_flex', required=True)
+    device_type = fields.Selection(
+        [
+            ('clover_pocket', 'Clover Pocket'),
+            ('clover_flex', 'Clover Flex'),
+            ('clover_mini', 'Clover Mini'),
+        ],
+        default='clover_pocket',
+        required=True,
+    )
     device_serial = fields.Char(string='HSN', help='Terminal hardware serial number (HSN).')
+    print_receipt_on_terminal = fields.Boolean(
+        string='Print Receipt on Terminal',
+        default=False,
+        help='Enable receipt printing on supported Clover terminals with built-in printers.',
+    )
     request_timeout_seconds = fields.Integer(default=120, required=True)
     signature_mode = fields.Selection(
         [

--- a/pos_cardpointe_poc/services/cardpointe_terminal.py
+++ b/pos_cardpointe_poc/services/cardpointe_terminal.py
@@ -224,6 +224,14 @@ class CardPointeTerminalClient:
             'orderId': order_id,
             'includeSignature': bool(include_signature),
         }
+        receipt_requested = bool(self.config.print_receipt_on_terminal)
+        if self.config.device_type == 'clover_flex':
+            payload['printReceipt'] = receipt_requested
+        _logger.info(
+            "CardPointe authCard receipt printing requested=%s device_type=%s",
+            receipt_requested if self.config.device_type == 'clover_flex' else False,
+            self.config.device_type,
+        )
         result = self._request(
             'POST',
             '/v4/authCard',

--- a/pos_cardpointe_poc/tests/__init__.py
+++ b/pos_cardpointe_poc/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_signature_policy
+from . import test_terminal_auth_payload

--- a/pos_cardpointe_poc/tests/test_terminal_auth_payload.py
+++ b/pos_cardpointe_poc/tests/test_terminal_auth_payload.py
@@ -1,0 +1,86 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+def _load_terminal_module():
+    http_module = types.ModuleType('odoo.addons.payment_cardpointe_base.services.http')
+    http_module.CardPointeRequestError = Exception
+    http_module.redact_payload = lambda payload: payload
+    http_module.request_json = lambda *args, **kwargs: (200, {}, '{}', {})
+    http_module.safe_log_headers = lambda headers: headers
+    http_module.safe_truncate = lambda value, limit=200: value
+
+    money_module = types.ModuleType('odoo.addons.payment_cardpointe_base.services.money')
+    money_module.dollars_to_implied_cents = lambda amount: str(int(round(float(amount) * 100)))
+
+    normalize_module = types.ModuleType('odoo.addons.payment_cardpointe_base.services.normalize')
+    normalize_module.normalize_terminal_authcard_response = (
+        lambda http_status, data: {'ok': True, 'status': 'ok', 'resptext': 'ok'}
+    )
+
+    sys.modules.setdefault('odoo', types.ModuleType('odoo'))
+    sys.modules.setdefault('odoo.addons', types.ModuleType('odoo.addons'))
+    sys.modules.setdefault('odoo.addons.payment_cardpointe_base', types.ModuleType('odoo.addons.payment_cardpointe_base'))
+    sys.modules.setdefault(
+        'odoo.addons.payment_cardpointe_base.services',
+        types.ModuleType('odoo.addons.payment_cardpointe_base.services'),
+    )
+    sys.modules['odoo.addons.payment_cardpointe_base.services.http'] = http_module
+    sys.modules['odoo.addons.payment_cardpointe_base.services.money'] = money_module
+    sys.modules['odoo.addons.payment_cardpointe_base.services.normalize'] = normalize_module
+
+    module_path = pathlib.Path(__file__).resolve().parents[1] / 'services' / 'cardpointe_terminal.py'
+    spec = importlib.util.spec_from_file_location('cardpointe_terminal', module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Config:
+    def __init__(self, device_type, print_receipt_on_terminal):
+        self.base_url = 'https://bolt-uat.cardpointe.com/api'
+        self.auth_key = 'secret'
+        self.merchant_id = 'mid'
+        self.device_serial = 'hsn'
+        self.request_timeout_seconds = 30
+        self.device_type = device_type
+        self.print_receipt_on_terminal = print_receipt_on_terminal
+
+
+class TestTerminalAuthPayload(unittest.TestCase):
+    def setUp(self):
+        self.module = _load_terminal_module()
+
+    def test_auth_payload_sends_print_receipt_for_flex(self):
+        client = self.module.CardPointeTerminalClient(_Config('clover_flex', True))
+        seen = {}
+
+        def fake_request(method, path, payload=None, session_key=None, timeout=30):
+            seen['payload'] = dict(payload or {})
+            return {'ok': False, 'status': 'error', 'message': 'stop'}
+
+        client._request = fake_request
+        client.auth_card_with_session(1.00, 'ORDER-1', 'SESSION-1', include_signature=True)
+
+        self.assertIn('printReceipt', seen['payload'])
+        self.assertTrue(seen['payload']['printReceipt'])
+
+    def test_auth_payload_omits_print_receipt_for_pocket(self):
+        client = self.module.CardPointeTerminalClient(_Config('clover_pocket', True))
+        seen = {}
+
+        def fake_request(method, path, payload=None, session_key=None, timeout=30):
+            seen['payload'] = dict(payload or {})
+            return {'ok': False, 'status': 'error', 'message': 'stop'}
+
+        client._request = fake_request
+        client.auth_card_with_session(1.00, 'ORDER-1', 'SESSION-1', include_signature=False)
+
+        self.assertNotIn('printReceipt', seen['payload'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pos_cardpointe_poc/views/cardpointe_terminal_config_views.xml
+++ b/pos_cardpointe_poc/views/cardpointe_terminal_config_views.xml
@@ -18,6 +18,8 @@
                         <field name="base_url"/>
                         <field name="merchant_id"/>
                         <field name="device_type"/>
+                        <field name="print_receipt_on_terminal"
+                               attrs="{'invisible': [('device_type', '!=', 'clover_flex')]}"/>
                         <field name="device_serial"/>
                         <field name="auth_key" password="True"/>
                         <field name="request_timeout_seconds"/>

--- a/pos_cardpointe_receipts/__init__.py
+++ b/pos_cardpointe_receipts/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import services

--- a/pos_cardpointe_receipts/__manifest__.py
+++ b/pos_cardpointe_receipts/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'POS CardPointe Receipts',
+    'version': '18.0.1.0.0',
+    'summary': 'Backend CardPointe terminal receipt reprint scaffold for POS payments',
+    'category': 'Point of Sale',
+    'license': 'LGPL-3',
+    'depends': ['pos_cardpointe_poc'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/pos_payment_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/pos_cardpointe_receipts/models/__init__.py
+++ b/pos_cardpointe_receipts/models/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_payment

--- a/pos_cardpointe_receipts/models/pos_payment.py
+++ b/pos_cardpointe_receipts/models/pos_payment.py
@@ -1,0 +1,77 @@
+import logging
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+from odoo.addons.pos_cardpointe_receipts.services.cardpointe_receipt import CardPointeTerminalReceiptService
+
+_logger = logging.getLogger(__name__)
+
+
+class PosPayment(models.Model):
+    _inherit = 'pos.payment'
+
+    cardpointe_reprint_attempt_count = fields.Integer(
+        string='CardPointe Reprint Attempts',
+        default=0,
+        readonly=True,
+        copy=False,
+    )
+
+    def _is_cardpointe_terminal_payment(self):
+        self.ensure_one()
+        payment_method = self.payment_method_id
+        return bool(payment_method and payment_method.use_payment_terminal == 'cardpointe_poc')
+
+    def _cardpointe_reprint_precheck(self):
+        self.ensure_one()
+
+        if not self._is_cardpointe_terminal_payment():
+            raise UserError(_('Receipt reprint is only available for CardPointe terminal payments.'))
+
+        if not self.cardpointe_ok or self.cardpointe_status != 'approved':
+            raise UserError(_('Receipt reprint is only available for approved CardPointe payments.'))
+
+        if not self.cardpointe_retref:
+            raise UserError(_('Missing CardPointe reference (retref); cannot reprint receipt.'))
+
+        terminal_config = self.payment_method_id.cardpointe_config_id
+        if not terminal_config:
+            raise UserError(_('CardPointe terminal configuration is missing on this payment method.'))
+
+        if not terminal_config.device_serial:
+            raise UserError(_('CardPointe terminal HSN is missing on the terminal configuration.'))
+
+        return terminal_config
+
+    def action_cardpointe_reprint_receipt(self):
+        self.ensure_one()
+        terminal_config = self._cardpointe_reprint_precheck()
+
+        service = CardPointeTerminalReceiptService(terminal_config)
+        order_id = self.pos_order_id.pos_reference or self.pos_order_id.name
+        result = service.reprint_receipt(retref=self.cardpointe_retref, order_id=order_id)
+
+        self.cardpointe_reprint_attempt_count += 1
+
+        _logger.info(
+            "CardPointe receipt reprint result payment_id=%s retref=%s status=%s ok=%s",
+            self.id,
+            self.cardpointe_retref,
+            result.get('status'),
+            result.get('ok'),
+        )
+
+        if not result.get('ok'):
+            raise UserError(result.get('message') or _('CardPointe receipt reprint failed.'))
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': _('CardPointe Receipt Reprint'),
+                'message': result.get('message') or _('Receipt reprint request sent to terminal.'),
+                'type': 'success',
+                'sticky': False,
+            },
+        }

--- a/pos_cardpointe_receipts/models/pos_payment.py
+++ b/pos_cardpointe_receipts/models/pos_payment.py
@@ -11,6 +11,10 @@ _logger = logging.getLogger(__name__)
 class PosPayment(models.Model):
     _inherit = 'pos.payment'
 
+    cardpointe_is_terminal_payment = fields.Boolean(
+        compute='_compute_cardpointe_is_terminal_payment',
+        string='Is CardPointe Terminal Payment',
+    )
     cardpointe_reprint_attempt_count = fields.Integer(
         string='CardPointe Reprint Attempts',
         default=0,
@@ -18,10 +22,16 @@ class PosPayment(models.Model):
         copy=False,
     )
 
+    def _compute_cardpointe_is_terminal_payment(self):
+        for payment in self:
+            payment.cardpointe_is_terminal_payment = bool(
+                payment.payment_method_id
+                and payment.payment_method_id.use_payment_terminal == 'cardpointe_poc'
+            )
+
     def _is_cardpointe_terminal_payment(self):
         self.ensure_one()
-        payment_method = self.payment_method_id
-        return bool(payment_method and payment_method.use_payment_terminal == 'cardpointe_poc')
+        return bool(self.cardpointe_is_terminal_payment)
 
     def _cardpointe_reprint_precheck(self):
         self.ensure_one()

--- a/pos_cardpointe_receipts/security/ir.model.access.csv
+++ b/pos_cardpointe_receipts/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_pos_payment_cardpointe_reprint_manager,access.pos.payment.cardpointe.reprint.manager,point_of_sale.model_pos_payment,point_of_sale.group_pos_manager,1,1,0,0

--- a/pos_cardpointe_receipts/services/__init__.py
+++ b/pos_cardpointe_receipts/services/__init__.py
@@ -1,0 +1,1 @@
+from . import cardpointe_receipt

--- a/pos_cardpointe_receipts/services/cardpointe_receipt.py
+++ b/pos_cardpointe_receipts/services/cardpointe_receipt.py
@@ -1,0 +1,28 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class CardPointeTerminalReceiptService:
+    """Scaffold service for terminal-side CardPointe receipt reprint calls."""
+
+    def __init__(self, terminal_config):
+        self.config = terminal_config
+
+    def reprint_receipt(self, retref, order_id=None):
+        _logger.info(
+            "CardPointe receipt reprint requested device_type=%s hsn=%s retref_present=%s order_id=%s",
+            self.config.device_type,
+            self.config.device_serial,
+            bool(retref),
+            order_id,
+        )
+
+        # TODO(cardpointe-receipts): Integrate the concrete CardPointe/Bolt endpoint for
+        # terminal receipt reprint once endpoint details (path, auth headers, payload, and
+        # success/error response mapping) are finalized and documented for this integration.
+        return {
+            'ok': False,
+            'status': 'not_implemented',
+            'message': 'Terminal receipt reprint endpoint is not implemented yet.',
+        }

--- a/pos_cardpointe_receipts/views/pos_payment_views.xml
+++ b/pos_cardpointe_receipts/views/pos_payment_views.xml
@@ -4,17 +4,19 @@
         <field name="model">pos.payment</field>
         <field name="inherit_id" ref="point_of_sale.view_pos_payment_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//header" position="inside">
-                <button name="action_cardpointe_reprint_receipt"
-                        string="Reprint CardPointe Receipt"
-                        type="object"
-                        class="oe_highlight"
-                        groups="point_of_sale.group_pos_manager"
-                        attrs="{'invisible': ['|', ('payment_method_id.use_payment_terminal', '!=', 'cardpointe_poc'), ('cardpointe_status', '!=', 'approved')]}"/>
-            </xpath>
-            <xpath expr="//sheet//group" position="inside">
+            <xpath expr="//sheet" position="inside">
+                <group string="CardPointe Receipt">
+                    <button name="action_cardpointe_reprint_receipt"
+                            string="Reprint CardPointe Receipt"
+                            type="object"
+                            class="oe_highlight"
+                            groups="point_of_sale.group_pos_manager"
+                            attrs="{'invisible': ['|', ('payment_method_id.use_payment_terminal', '!=', 'cardpointe_poc'), ('cardpointe_status', '!=', 'approved')]}"/>
+                </group>
+                <group>
                 <field name="cardpointe_reprint_attempt_count" readonly="1"
                        attrs="{'invisible': [('payment_method_id.use_payment_terminal', '!=', 'cardpointe_poc')]}"/>
+                </group>
             </xpath>
         </field>
     </record>

--- a/pos_cardpointe_receipts/views/pos_payment_views.xml
+++ b/pos_cardpointe_receipts/views/pos_payment_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="inside">
                 <group string="CardPointe Receipt">
+                    <field name="cardpointe_status" invisible="1"/>
                     <button name="action_cardpointe_reprint_receipt"
                             string="Reprint CardPointe Receipt"
                             type="object"

--- a/pos_cardpointe_receipts/views/pos_payment_views.xml
+++ b/pos_cardpointe_receipts/views/pos_payment_views.xml
@@ -1,0 +1,21 @@
+<odoo>
+    <record id="view_pos_payment_form_cardpointe_reprint" model="ir.ui.view">
+        <field name="name">pos.payment.form.cardpointe.reprint</field>
+        <field name="model">pos.payment</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_payment_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button name="action_cardpointe_reprint_receipt"
+                        string="Reprint CardPointe Receipt"
+                        type="object"
+                        class="oe_highlight"
+                        groups="point_of_sale.group_pos_manager"
+                        attrs="{'invisible': ['|', ('payment_method_id.use_payment_terminal', '!=', 'cardpointe_poc'), ('cardpointe_status', '!=', 'approved')]}"/>
+            </xpath>
+            <xpath expr="//sheet//group" position="inside">
+                <field name="cardpointe_reprint_attempt_count" readonly="1"
+                       attrs="{'invisible': [('payment_method_id.use_payment_terminal', '!=', 'cardpointe_poc')]}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/pos_cardpointe_receipts/views/pos_payment_views.xml
+++ b/pos_cardpointe_receipts/views/pos_payment_views.xml
@@ -6,17 +6,18 @@
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="inside">
                 <group string="CardPointe Receipt">
+                    <field name="cardpointe_is_terminal_payment" invisible="1"/>
                     <field name="cardpointe_status" invisible="1"/>
                     <button name="action_cardpointe_reprint_receipt"
                             string="Reprint CardPointe Receipt"
                             type="object"
                             class="oe_highlight"
                             groups="point_of_sale.group_pos_manager"
-                            attrs="{'invisible': ['|', ('payment_method_id.use_payment_terminal', '!=', 'cardpointe_poc'), ('cardpointe_status', '!=', 'approved')]}"/>
+                            attrs="{'invisible': ['|', ('cardpointe_is_terminal_payment', '=', False), ('cardpointe_status', '!=', 'approved')]}"/>
                 </group>
                 <group>
                 <field name="cardpointe_reprint_attempt_count" readonly="1"
-                       attrs="{'invisible': [('payment_method_id.use_payment_terminal', '!=', 'cardpointe_poc')]}"/>
+                       attrs="{'invisible': [('cardpointe_is_terminal_payment', '=', False)]}"/>
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
### Motivation

- Expose per-terminal option to request receipt printing on supported Clover devices and allow different Clover device types in configuration. 
- Provide a backend scaffold to request terminal-side receipt reprints from CardPointe and surface this action on POS payments. 

### Description

- Extended `pos.cardpointe.terminal.config` to support multiple `device_type` values (`clover_pocket`, `clover_flex`, `clover_mini`) and added a `print_receipt_on_terminal` boolean to control terminal receipt printing. 
- Updated terminal config form view to show `print_receipt_on_terminal` only for `clover_flex`. 
- Modified `CardPointeTerminalClient.auth_card_with_session` to include `printReceipt` in the `/v4/authCard` payload when `device_type` is `clover_flex` and to log the request decision. 
- Added a new addon `pos_cardpointe_receipts` containing: a manifest, access control entry, a scaffold `CardPointeTerminalReceiptService` that logs reprint requests (currently not implemented), a `pos.payment` extension that exposes `action_cardpointe_reprint_receipt` plus a reprint attempt counter, and POS view changes to trigger reprints for CardPointe payments. 
- Added unit tests `test_terminal_auth_payload.py` to validate that `printReceipt` is sent for `clover_flex` and omitted for `clover_pocket`, and updated test imports. 

### Testing

- Added and ran unit tests in `pos_cardpointe_poc/tests/test_terminal_auth_payload.py` which assert `printReceipt` is present for `clover_flex` and absent for `clover_pocket`, and these tests passed. 
- Existing `pos_cardpointe_poc/tests/test_signature_policy.py` remains included in the test suite and passed. 
- No integration/endpoint tests were added for the receipt reprint service because the terminal reprint endpoint is not yet implemented.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c969bca7ac832895e9078109bbe266)