### PR TITLE
Add CardPointe ecomind support for CNP auth flows

### DIFF
--- a/payment_cardpointe/controllers/main.py
+++ b/payment_cardpointe/controllers/main.py
@@ -25,6 +25,7 @@ class CardPointeController(http.Controller):
         partner_id = kwargs.get('partner_id')
         meta = kwargs.get('meta')
         save_token = self._cardpointe_is_truthy(kwargs.get('save_token'))
+        flow = kwargs.get('flow')
 
         _logger.info(
             "[CARDPOINTE] process request received tx_ref=%s partner_id=%s token_present=%s save_token=%s",
@@ -89,9 +90,9 @@ class CardPointeController(http.Controller):
         if is_validation:
             result = tx_sudo._cardpointe_tokenize_from_token(token, meta=meta)
         elif save_token:
-            result = tx_sudo._cardpointe_charge_and_tokenize_from_token(token, meta=meta)
+            result = tx_sudo._cardpointe_charge_and_tokenize_from_token(token, meta=meta, flow=flow)
         else:
-            result = tx_sudo._cardpointe_charge_from_token(token, meta=meta)
+            result = tx_sudo._cardpointe_charge_from_token(token, meta=meta, flow=flow)
 
         if not result.get('ok'):
             _logger.warning(

--- a/payment_cardpointe/models/payment_transaction.py
+++ b/payment_cardpointe/models/payment_transaction.py
@@ -15,6 +15,44 @@ ENDPOINT_CHARGE = "/auth"
 class PaymentTransaction(models.Model):
     _inherit = 'payment.transaction'
 
+    def _cardpointe_get_ecomind(self, flow=None):
+        """Resolve the CardPointe ecomind indicator for CNP auth requests."""
+        self.ensure_one()
+        flow_value = (
+            flow
+            or self.env.context.get('cardpointe_cnp_flow')
+            or self.env.context.get('cardpointe_flow')
+            or ''
+        )
+        normalized_flow = str(flow_value).strip().lower()
+        if normalized_flow in ('e', 't', 'r'):
+            return normalized_flow.upper()
+
+        flow_map = {
+            # Ecommerce / web / mobile / customer initiated
+            'ecommerce': 'E',
+            'web': 'E',
+            'mobile': 'E',
+            'direct': 'E',
+            'cit': 'E',
+            'customer_initiated': 'E',
+            # Phone or mail order
+            'telephone': 'T',
+            'phone': 'T',
+            'mail': 'T',
+            'moto': 'T',
+            # Merchant-initiated recurring
+            'recurring': 'R',
+            'mit': 'R',
+            'merchant_initiated': 'R',
+        }
+        if normalized_flow in flow_map:
+            return flow_map[normalized_flow]
+
+        if self.token_id and self.operation in ('offline',):
+            return 'R'
+        return 'E'
+
     def _get_specific_processing_values(self, processing_values):
         self.ensure_one()
         res = super()._get_specific_processing_values(processing_values)
@@ -47,7 +85,7 @@ class PaymentTransaction(models.Model):
         full_message = ("%s%s" % (("[%s] " % code) if code else "", message or _("Payment failed."))).strip()
         self._set_error(full_message)
 
-    def _cardpointe_charge_from_token(self, token, meta=None):
+    def _cardpointe_charge_from_token(self, token, meta=None, flow=None):
         self.ensure_one()
         if self.provider_code != 'cardpointe':
             return {'ok': False, 'message': _("CardPointe: invalid provider.")}
@@ -72,6 +110,7 @@ class PaymentTransaction(models.Model):
             "currency": self.currency_id.name,
             "capture": "y",
             "orderid": self.reference,
+            "ecomind": self._cardpointe_get_ecomind(flow=flow),
         }
 
         response = provider.with_context(
@@ -96,7 +135,7 @@ class PaymentTransaction(models.Model):
         self._cardpointe_fail(message, code)
         return {'ok': False, 'message': message, 'raw': raw}
 
-    def _cardpointe_charge_from_payment_token(self, payment_token):
+    def _cardpointe_charge_from_payment_token(self, payment_token, flow=None):
         """Charge using an existing Odoo payment.token backed by CardPointe profile/account ids."""
         self.ensure_one()
         if self.provider_code != 'cardpointe':
@@ -134,6 +173,7 @@ class PaymentTransaction(models.Model):
             "orderid": self.reference,
             "cof": "C",
             "cofscheduled": "N",
+            "ecomind": self._cardpointe_get_ecomind(flow=flow),
         }
 
         response = provider.with_context(
@@ -199,7 +239,7 @@ class PaymentTransaction(models.Model):
             'provider_ref': provider_ref,
         }
 
-    def _cardpointe_charge_and_tokenize_from_token(self, token, meta=None):
+    def _cardpointe_charge_and_tokenize_from_token(self, token, meta=None, flow=None):
         self.ensure_one()
         if self.provider_code != 'cardpointe':
             return {'ok': False, 'message': _("CardPointe: invalid provider.")}
@@ -214,4 +254,4 @@ class PaymentTransaction(models.Model):
             return {'ok': False, 'message': message}
 
         provider._cardpointe_create_or_update_payment_token(partner, profile_result['data'])
-        return self._cardpointe_charge_from_token(token, meta=meta)
+        return self._cardpointe_charge_from_token(token, meta=meta, flow=flow)

--- a/payment_cardpointe/static/src/js/payment_form.js
+++ b/payment_cardpointe/static/src/js/payment_form.js
@@ -64,6 +64,7 @@ odoo.define('payment_cardpointe.payment_form', require => {
                             'token': tokenPayload.token,
                             'meta': tokenPayload.meta || {},
                             'save_token': saveToken,
+                            'flow': flow || 'direct',
                             'access_token': processingValues.access_token || this.txContext.accessToken,
                         }
                     });

--- a/payment_token_autocharge/models/account_move.py
+++ b/payment_token_autocharge/models/account_move.py
@@ -45,7 +45,7 @@ class AccountMove(models.Model):
                                                 'operation': 'offline',
                                                 'invoice_ids': [(6, 0, [rec.id])],
                                             })
-                    transaction._send_payment_request()
+                    transaction.with_context(cardpointe_cnp_flow='recurring')._send_payment_request()
                     transaction._cr.commit()
                 except Exception as exp:
                     rec.message_post(


### PR DESCRIPTION
### Motivation
- UAT requires CardPointe card-not-present (CNP) auths to include the `ecomind` indicator so interchange is handled correctly.
- `ecomind` should be derived from the payment flow/context (web/phone/recurring) instead of hardcoding to ensure correct mapping for one-time web charges, save-and-charge flows, and stored-token CIT/MIT flows.

### Description
- Added a centralized resolver `PaymentTransaction._cardpointe_get_ecomind(flow=None)` that maps flows/context to `E`, `T`, or `R` with sensible defaults and offline-token fallback to `R`.
- Included `ecomind` into CNP `/auth` payloads by adding it to the payload in `PaymentTransaction._cardpointe_charge_from_token` and `PaymentTransaction._cardpointe_charge_from_payment_token`.
- Threaded `flow` through the website controller and transaction call chain by accepting `flow` in `payment.cardpointe` request handling and in `PaymentTransaction` charge/tokenize methods (`flow` param added to `*_charge_*` and `*_charge_and_tokenize_from_token`).
- Updated frontend to send `flow` (defaulting to `'direct'` for current website checkout) in the `/payment/cardpointe/process` RPC, and marked automatic invoice autocharge calls with `cardpointe_cnp_flow='recurring'` context so merchant-initiated offline charges map to `R`.
- Modified files: `payment_cardpointe/models/payment_transaction.py`, `payment_cardpointe/controllers/main.py`, `payment_cardpointe/static/src/js/payment_form.js`, `payment_token_autocharge/models/account_move.py`.

### Testing
- Running `python payment_cardpointe_base/tests/test_services_smoke.py` succeeded (OK).
- Running `python payment_cardpointe_base/tests/test_gateway_refund_logic.py` succeeded (OK).
- Running `python pos_cardpointe_poc/tests/test_terminal_auth_payload.py` succeeded (OK).
- A combined `python -m unittest ...` invocation failed in this environment due to missing `odoo` import (environment limitation), but individual test scripts above completed successfully.
- Byte-compile check `python -m py_compile payment_cardpointe/models/payment_transaction.py payment_cardpointe/controllers/main.py payment_token_autocharge/models/account_move.py` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e24c67ac588328a79f06a001dd6b2b)